### PR TITLE
documentation and bug fixes

### DIFF
--- a/R/EGA.R
+++ b/R/EGA.R
@@ -238,7 +238,7 @@
 #'
 #' @export
 # EGA ----
-# Updated 06.08.2023
+# Updated 07.08.2023
 EGA <- function (
     data, n = NULL,
     corr = c("auto", "pearson", "spearman"),

--- a/R/EGA.fit.R
+++ b/R/EGA.fit.R
@@ -270,7 +270,7 @@ EGA.fit <- function(
   # Determine best fitting solution
   fit_values <- apply(
     search_unique, 1, function(membership){
-      tefi(correlation_matrix, membership)
+      tefi(correlation_matrix, membership, verbose = FALSE)
     }$VN.Entropy.Fit
   )
   
@@ -370,9 +370,12 @@ EGA.fit_errors <- function(data, n, plot.EGA, verbose)
 
 #' @exportS3Method 
 # S3 Print Method ----
-# Updated 27.06.2023
+# Updated 07.08.2023
 print.EGA.fit <- function(x, ...)
 {
+  
+  # Add class to network
+  class(x$EGA$network) <- "EGA.network"
   
   # Print network estimation
   print(x$EGA$network)

--- a/R/S3plots.R
+++ b/R/S3plots.R
@@ -3,8 +3,8 @@
 #' @name EGAnet-plot
 #' 
 #' @description General usage for plots created by \code{\link{EGAnet}}'s S3 methods.
-#' Plots across the \code{\link{EGAnet}} package leverage \code{\link[GGally]{ggnet2}} 
-#' and \code{\link[ggplot2]{ggplot}}.
+#' Plots across the \code{\link{EGAnet}} package leverage \{\link{GGally}\}'s \code{\link[GGally]{ggnet2}} 
+#' and \{\link{ggplot2}\}'s \code{\link[ggplot2]{ggplot}}.
 #' 
 #' Most plots allow the full usage of the \code{gg*} series functionality and therefore
 #' plotting arguments should be referenced through those packages rather than here in
@@ -129,6 +129,8 @@
 #' In any network plots, the \code{color.palette} argument can be used to
 #' select color palettes from \code{\link[EGAnet]{color_palette_EGA}} as well
 #' as those in the color scheme of \code{\link[RColorBrewer]{RColorBrewer}}
+#' 
+#' \emph{For more worked examples than below, see \href{https://tinyurl.com/plots-in-eganet}{Plots in \{EGAnet\}}}
 #' 
 #' @examples
 #' \dontrun{

--- a/R/bootEGA.R
+++ b/R/bootEGA.R
@@ -1386,7 +1386,7 @@ estimate_typical_EGA.fit <- function(results, ellipse)
   # Determine best fitting solution
   fit_values <- apply(
     search_unique, 1, function(membership){
-      tefi(ega_object$correlation, membership)
+      tefi(ega_object$correlation, membership, verbose = FALSE)
     }$VN.Entropy.Fit
   )
   

--- a/R/genTEFI.R
+++ b/R/genTEFI.R
@@ -22,6 +22,12 @@
 #' factor or community)}
 #' 
 #' }
+#' 
+#' @param verbose Boolean (length = 1).
+#' Whether messages and (insignificant) warnings should be output.
+#' Defaults to \code{TRUE} to see all messages and warnings for every 
+#' function call.
+#' Set to \code{FALSE} to ignore messages and warnings
 #'
 #' @return Returns a three-column data frame of the Generalized Total Entropy 
 #' Fit Index using Von Neumman's entropy (\code{VN.Entropy.Fit}) (first column), as well as
@@ -44,21 +50,21 @@
 #' @export
 # Total Entropy Fit Index Function (for correlation matrices)
 # Updated 07.08.2023
-genTEFI <- function(data, structure = NULL)
+genTEFI <- function(data, structure = NULL, verbose = TRUE)
 {
   
   # Argument errors
-  genTEFI_errors(data, structure)
+  genTEFI_errors(data, structure, verbose)
   
   # Perform TEFI
-  return(tefi(data, structure))
+  return(tefi(data, structure, verbose))
 
 }
 
 #' @noRd
 # Argument errors
 # Updated 07.08.2023
-genTEFI_errors <- function(data, structure)
+genTEFI_errors <- function(data, structure, verbose)
 {
   
   # 'data' errors
@@ -73,6 +79,10 @@ genTEFI_errors <- function(data, structure)
     object_error(structure, "list")
     length_error(structure, 2)
   }
+  
+  # 'verbose' errors
+  length_error(verbose, 1)
+  typeof_error(verbose, "logical")
   
 }
 

--- a/man/EGAnet-plot.Rd
+++ b/man/EGAnet-plot.Rd
@@ -6,8 +6,8 @@
 \title{S3 Plot Methods for \code{\link{EGAnet}}}
 \description{
 General usage for plots created by \code{\link{EGAnet}}'s S3 methods.
-Plots across the \code{\link{EGAnet}} package leverage \code{\link[GGally]{ggnet2}} 
-and \code{\link[ggplot2]{ggplot}}.
+Plots across the \code{\link{EGAnet}} package leverage \{\link{GGally}\}'s \code{\link[GGally]{ggnet2}} 
+and \{\link{ggplot2}\}'s \code{\link[ggplot2]{ggplot}}.
 
 Most plots allow the full usage of the \code{gg*} series functionality and therefore
 plotting arguments should be referenced through those packages rather than here in
@@ -141,6 +141,8 @@ are the same length as the number of communities in the plot.
 In any network plots, the \code{color.palette} argument can be used to
 select color palettes from \code{\link[EGAnet]{color_palette_EGA}} as well
 as those in the color scheme of \code{\link[RColorBrewer]{RColorBrewer}}
+
+\emph{For more worked examples than below, see \href{https://tinyurl.com/plots-in-eganet}{Plots in \{EGAnet\}}}
 }
 
 \examples{

--- a/man/genTEFI.Rd
+++ b/man/genTEFI.Rd
@@ -4,7 +4,7 @@
 \alias{genTEFI}
 \title{Generalized Total Entropy Fit Index using Von Neumman's entropy (Quantum Information Theory) for correlation matrices}
 \usage{
-genTEFI(data, structure = NULL)
+genTEFI(data, structure = NULL, verbose = TRUE)
 }
 \arguments{
 \item{data}{Matrix, data frame, or \code{\link[EGAnet]{hierEGA}} object.
@@ -25,6 +25,12 @@ the second-order structure (numbers or labels for each item in each second-order
 factor or community)}
 
 }}
+
+\item{verbose}{Boolean (length = 1).
+Whether messages and (insignificant) warnings should be output.
+Defaults to \code{TRUE} to see all messages and warnings for every 
+function call.
+Set to \code{FALSE} to ignore messages and warnings}
 }
 \value{
 Returns a three-column data frame of the Generalized Total Entropy 

--- a/man/tefi.Rd
+++ b/man/tefi.Rd
@@ -4,7 +4,7 @@
 \alias{tefi}
 \title{Total Entropy Fit Index using Von Neumman's entropy (Quantum Information Theory) for correlation matrices}
 \usage{
-tefi(data, structure = NULL)
+tefi(data, structure = NULL, verbose = TRUE)
 }
 \arguments{
 \item{data}{Matrix, data frame, or \code{*EGA} class object.
@@ -13,7 +13,13 @@ All \code{*EGA} objects are accepted. \code{\link[EGAnet]{hierEGA}}
 input will produced the Generalized TEFI (see \code{\link[EGAnet]{genTEFI}})}
 
 \item{structure}{Numeric or character vector (length = \code{ncol(data)}).
-Can be theoretical factors or the structure detected by \code{\link{EGA}}.}
+Can be theoretical factors or the structure detected by \code{\link{EGA}}}
+
+\item{verbose}{Boolean (length = 1).
+Whether messages and (insignificant) warnings should be output.
+Defaults to \code{TRUE} to see all messages and warnings for every 
+function call.
+Set to \code{FALSE} to ignore messages and warnings}
 }
 \value{
 Returns a data frame with columns:


### PR DESCRIPTION
o fixes excessive warning output from `tefi` when using `EGA.fit`

o documentation about xoshiro256++ non-overlapping sequences for parallelization (in short, _extremely_ improbable there will be overlapping sequences; upper bound for 1 trillion seeds = 1.593092e-34)