### PR TITLE
`net.loads` defaults to "revised"

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,8 @@ WEBSITE: https://r-ega.net
 
 + ADD: a general function called `information` to compute several information theory measures
 
++ UPDATE: default 'loading.method' for `net.loads` has been changed to "revised" moving forward -- the previous default in versions <= 2.0.6 can be obtained using "original"
+
 + UPDATE: `invariance` handles more than 2 groups (plots up to 4 groups pairwise)
 
 + UPDATE: added 'signed' argument in `jsd` to allow for signed or absolute networks to be used in computations (includes downstream functions: `infoCluster`)

--- a/R/hierEGA.R
+++ b/R/hierEGA.R
@@ -12,9 +12,9 @@
 #'
 #' @param loading.method Character (length = 1).
 #' Sets network loading calculation based on implementation
-#' described in \code{"BRM"} (Christensen & Golino, 2021) or
-#' an \code{"experimental"} implementation (Christensen et al., 2024).
-#' Defaults to \code{"experimental"}
+#' described in \code{"original"} (Christensen & Golino, 2021) or
+#' the \code{"revised"} (Christensen et al., 2024) implementation.
+#' Defaults to \code{"revised"}
 #'
 #' @param rotation Character.
 #' A rotation to use to obtain a simpler structure.
@@ -277,11 +277,11 @@
 #' @export
 #'
 # Hierarchical EGA ----
-# Updated 22.07.2024
+# Updated 12.08.2024
 hierEGA <- function(
     data,
     # `net.scores` arguments
-    loading.method = c("BRM", "experimental"),
+    loading.method = c("original", "revised"),
     rotation = NULL, scores = c("factor", "network"),
     loading.structure = c("simple", "full"),
     impute = c("mean", "median", "none"),
@@ -308,7 +308,8 @@ hierEGA <- function(
 
   # Check for missing arguments (argument, default, function)
   ## `net.scores`
-  loading.method <- set_default(loading.method, "experimental", net.loads)
+  # loading.method <- set_default(loading.method, "experimental", net.loads)
+  # Push default check to `net.laods`
   scores <- set_default(scores, "network", hierEGA)
   loading.structure <- set_default(loading.structure, "simple", hierEGA)
   impute <- set_default(impute, "none", net.scores)

--- a/man/hierEGA.Rd
+++ b/man/hierEGA.Rd
@@ -6,7 +6,7 @@
 \usage{
 hierEGA(
   data,
-  loading.method = c("BRM", "experimental"),
+  loading.method = c("original", "revised"),
   rotation = NULL,
   scores = c("factor", "network"),
   loading.structure = c("simple", "full"),
@@ -29,9 +29,9 @@ Should consist only of variables to be used in the analysis
 
 \item{loading.method}{Character (length = 1).
 Sets network loading calculation based on implementation
-described in \code{"BRM"} (Christensen & Golino, 2021) or
-an \code{"experimental"} implementation (Christensen et al., 2024).
-Defaults to \code{"experimental"}}
+described in \code{"original"} (Christensen & Golino, 2021) or
+the \code{"revised"} (Christensen et al., 2024) implementation.
+Defaults to \code{"revised"}}
 
 \item{rotation}{Character.
 A rotation to use to obtain a simpler structure.

--- a/man/net.loads.Rd
+++ b/man/net.loads.Rd
@@ -7,7 +7,7 @@
 net.loads(
   A,
   wc,
-  loading.method = c("BRM", "experimental"),
+  loading.method = c("original", "revised"),
   scaling = 2,
   rotation = NULL,
   ...
@@ -23,9 +23,9 @@ then \code{wc} is automatically detected}
 
 \item{loading.method}{Character (length = 1).
 Sets network loading calculation based on implementation
-described in \code{"BRM"} (Christensen & Golino, 2021) or
-an \code{"experimental"} implementation.
-Defaults to \code{"BRM"}}
+described in \code{"original"} (Christensen & Golino, 2021) or
+the \code{"revised"} (Christensen et al., 2024) implementation.
+Defaults to \code{"revised"}}
 
 \item{scaling}{Numeric (length = 1).
 Scaling factor for the magnitude of the \code{"experimental"} network loadings.
@@ -93,6 +93,11 @@ On the equivalency of factor and network loadings.
 Hallquist, M., Wright, A. C. G., & Molenaar, P. C. M. (2019).
 Problems with centrality measures in psychopathology symptom networks: Why network psychometrics cannot escape psychometric theory.
 \emph{Multivariate Behavioral Research}, 1-25.
+
+\strong{Revised network loadings} \cr
+Christensen, A. P., Golino, H., Abad, F. J., & Garrido, L. E. (2024).
+Revised network loadings.
+\emph{PsyArXiv}.
 }
 \author{
 Alexander P. Christensen <alexpaulchristensen@gmail.com> and Hudson Golino <hfg9s at virginia.edu>

--- a/man/net.scores.Rd
+++ b/man/net.scores.Rd
@@ -8,7 +8,7 @@ net.scores(
   data,
   A,
   wc,
-  loading.method = c("BRM", "experimental"),
+  loading.method = c("original", "revised"),
   rotation = NULL,
   scores = c("Anderson", "Bartlett", "components", "Harman", "network", "tenBerge",
     "Thurstone"),
@@ -30,12 +30,12 @@ then \code{wc} is automatically detected}
 
 \item{loading.method}{Character (length = 1).
 Sets network loading calculation based on implementation
-described in \code{"BRM"} (Christensen & Golino, 2021) or
-an \code{"experimental"} implementation.
-Defaults to \code{"BRM"}}
+described in \code{"original"} (Christensen & Golino, 2021) or
+the \code{"revised"} (Christensen et al., 2024) implementation.
+Defaults to \code{"revised"}}
 
 \item{rotation}{Character.
-A rotation to use to obtain a simpler structure. 
+A rotation to use to obtain a simpler structure.
 For a list of rotations, see \code{\link[GPArotation]{rotations}} for options.
 Defaults to \code{NULL} or no rotation.
 By setting a rotation, \code{scores} estimation will be
@@ -53,7 +53,7 @@ Whether simple structure or the saturated loading matrix
 should be used when computing scores.
 Defaults to \code{"simple"}
 
-\code{"simple"} structure more closely mirrors sum scores and CFA; 
+\code{"simple"} structure more closely mirrors sum scores and CFA;
 \code{"full"} structure more closely mirrors EFA
 
 Simple structure is the more "conservative" (established) approach
@@ -61,7 +61,7 @@ and is therefore the default. Treat \code{"full"} as experimental
 as proper vetting and validation has not been established}
 
 \item{impute}{Character (length = 1).
-If there are any missing data, then imputation can be implemented. 
+If there are any missing data, then imputation can be implemented.
 Available options:
 
 \itemize{
@@ -76,7 +76,7 @@ for that variable
 
 }}
 
-\item{...}{Additional arguments to be passed on to 
+\item{...}{Additional arguments to be passed on to
 \code{\link[EGAnet]{net.loads}} and
 \code{\link[psych]{factor.scores}}}
 }
@@ -91,8 +91,8 @@ rotated (\code{rot.scores}) scores. If \code{rotation = NULL}, then
 }
 \description{
 This function computes network scores computed based on
-each node's \code{strength} within each community in the network 
-(see \code{\link[EGAnet]{net.loads}}). These values are used as "network loadings" 
+each node's \code{strength} within each community in the network
+(see \code{\link[EGAnet]{net.loads}}). These values are used as "network loadings"
 for the weights of each variable.
 
 Network scores are computed as a formative composite rather than a reflective factor.
@@ -128,6 +128,11 @@ On the equivalency of factor and network loadings.
 Golino, H., Christensen, A. P., Moulder, R., Kim, S., & Boker, S. M. (2021).
 Modeling latent topics in social media using Dynamic Exploratory Graph Analysis: The case of the right-wing and left-wing trolls in the 2016 US elections.
 \emph{Psychometrika}.
+
+\strong{Revised network loadings} \cr
+Christensen, A. P., Golino, H., Abad, F. J., & Garrido, L. E. (2024).
+Revised network loadings.
+\emph{PsyArXiv}.
 }
 \author{
 Alexander P. Christensen <alexpaulchristensen@gmail.com> and Hudson F. Golino <hfg9s at virginia.edu>


### PR DESCRIPTION
+ changed `net.loads` default to `loading.method = "revised"`

+ message is thrown to let user know that the default has been updated

+ downstream functions have had their defaults updated: `hierEGA` and `net.scores`

+ `invariance` is not affected as the default was already used

+ confirmed nothing breaks when `devtools::check` (independently checked different examples and legacy arguments of `loading.method = "BRM"` and `loading.method = "experimental"`)